### PR TITLE
Mostra solo capoluoghi sulla mappa

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1476,6 +1476,10 @@ function renderMap() {
     const code = String(r.cod_stazione || "").trim();
     if (!code) continue;
 
+    const city = stationCity(code, r.nome_stazione || code);
+    if (!city) continue;
+    if (!isCapoluogoCity(city)) continue;
+
     const coords = stationCoords(code);
     if (!coords) continue;
 


### PR DESCRIPTION
### Motivation
- La mappa attualmente mostrava tutti i nodi/stazioni e va limitata ai soli capoluoghi di provincia per migliorare la leggibilità e ridurre il rumore visivo.

### Description
- Aggiunta una verifica in `renderMap()` nel file `docs/assets/app.js` che calcola `city = stationCity(code, ...)` e salta la stazione se `!isCapoluogoCity(city)`, evitando la creazione di marker per stazioni non-capoluogo.

### Testing
- Eseguito `node --check docs/assets/app.js` e l'analisi statica è risultata positiva.
- Avviato un server locale e catturato uno screenshot della dashboard con Playwright per verificare visivamente che i marker mostrino solo i capoluoghi (successo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993404c8230832abe79d9c59d0df0a9)