### PR TITLE
Filtra i marker della mappa ai capoluoghi di provincia

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1476,6 +1476,10 @@ function renderMap() {
     const code = String(r.cod_stazione || "").trim();
     if (!code) continue;
 
+    const city = stationCity(code, r.nome_stazione || code);
+    if (!city) continue;
+    if (!isCapoluogoCity(city)) continue;
+
     const coords = stationCoords(code);
     if (!coords) continue;
 
@@ -1575,8 +1579,11 @@ async function loadCapoluoghiAnyBase(primaryBase) {
   const base = ensureTrailingSlash(primaryBase);
   const tries = uniq([
     ...candidateFilePaths(base, "capoluoghi_provincia.csv"),
+    ...candidateFilePaths(base, "stations/capoluoghi_provincia.csv"),
     ...candidateFilePaths("data/", "capoluoghi_provincia.csv"),
-    ...candidateFilePaths("./data/", "capoluoghi_provincia.csv")
+    ...candidateFilePaths("./data/", "capoluoghi_provincia.csv"),
+    "data/stations/capoluoghi_provincia.csv",
+    "./data/stations/capoluoghi_provincia.csv"
   ]);
   for (const p of tries) {
     const t = await fetchTextOrNull(p);


### PR DESCRIPTION
### Motivation
- Ridurre il numero di marker mostrati sulla mappa limitandoli ai soli capoluoghi di provincia anziché a tutte le stazioni.
- Garantire che l'elenco dei capoluoghi venga trovato anche nell'attuale struttura dei dati del repository (`data/stations/`).

### Description
- Aggiornata la funzione di rendering della mappa in `docs/assets/app.js` per chiamare `stationCity(...)` e scartare le stazioni la cui città non è riconosciuta da `isCapoluogoCity(...)`, in modo da mostrare solo i capoluoghi.
- Estesi i percorsi esplorati da `loadCapoluoghiAnyBase` per includere `stations/capoluoghi_provincia.csv` e i file sotto `data/stations/` in modo da trovare correttamente `capoluoghi_provincia.csv` nella struttura del repo.
- Modifiche effettuate in `docs/assets/app.js` (inserite poche righe di filtro e nuovi candidate paths).

### Testing
- Eseguito `node --check docs/assets/app.js` e l'analisi sintattica è risultata positiva.
- Eseguito uno script Playwright che ha caricato `http://127.0.0.1:8000/index.html` e generato uno screenshot della pagina per verificare visivamente la riduzione dei marker, e lo script è terminato con successo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993404c8230832abe79d9c59d0df0a9)