### PR TITLE
Add station-level histogram data and filtering by departure/arrival

### DIFF
--- a/scripts/build_gold.py
+++ b/scripts/build_gold.py
@@ -214,6 +214,37 @@ def build_gold(cfg: Dict[str, Any], df: pd.DataFrame) -> Dict[str, pd.DataFrame]
     ).reset_index()
     out["hist_giorno_categoria"] = h_d
 
+    # Station-level histogram: departure and arrival perspectives
+    dep_hist = df.copy()
+    dep_hist["cod_stazione"] = dep_hist["cod_partenza"]
+    dep_hist["ruolo"] = "partenza"
+
+    arr_hist = df.copy()
+    arr_hist["cod_stazione"] = arr_hist["cod_arrivo"]
+    arr_hist["ruolo"] = "arrivo"
+
+    hist_station_src = pd.concat([dep_hist, arr_hist], ignore_index=True)
+
+    h_st_m = hist_station_src.groupby(
+        ["mese", "categoria", "cod_stazione", "ruolo", "bucket_ritardo_arrivo"],
+        dropna=False,
+    ).agg(
+        count=("_obs_id", "count"),
+        minuti_ritardo=("minuti_ritardo", "sum"),
+        minuti_anticipo=("minuti_anticipo", "sum"),
+    ).reset_index()
+    out["hist_stazioni_mese_categoria_ruolo"] = h_st_m
+
+    h_st_d = hist_station_src.groupby(
+        ["giorno", "ora", "categoria", "cod_stazione", "ruolo", "bucket_ritardo_arrivo"],
+        dropna=False,
+    ).agg(
+        count=("_obs_id", "count"),
+        minuti_ritardo=("minuti_ritardo", "sum"),
+        minuti_anticipo=("minuti_anticipo", "sum"),
+    ).reset_index()
+    out["hist_stazioni_giorno_categoria_ruolo"] = h_st_d
+
     od_m = agg_core(["mese", "categoria", "cod_partenza", "cod_arrivo"], df)
     od_d = agg_core(["giorno", "ora", "categoria", "cod_partenza", "cod_arrivo"], df)
 
@@ -323,6 +354,8 @@ def gold_keys() -> Dict[str, List[str]]:
         "kpi_mese": ["mese"],
         "hist_mese_categoria": ["mese", "categoria", "bucket_ritardo_arrivo"],
         "hist_giorno_categoria": ["giorno", "ora", "categoria", "bucket_ritardo_arrivo"],
+        "hist_stazioni_mese_categoria_ruolo": ["mese", "categoria", "cod_stazione", "ruolo", "bucket_ritardo_arrivo"],
+        "hist_stazioni_giorno_categoria_ruolo": ["giorno", "ora", "categoria", "cod_stazione", "ruolo", "bucket_ritardo_arrivo"],
         "od_mese_categoria": ["mese", "categoria", "cod_partenza", "cod_arrivo"],
         "od_giorno_categoria": ["giorno", "ora", "categoria", "cod_partenza", "cod_arrivo"],
         "stazioni_mese_categoria_ruolo": ["mese", "categoria", "cod_stazione", "ruolo"],


### PR DESCRIPTION
## Summary
This PR adds support for analyzing train performance metrics at the station level, enabling users to filter and visualize data by specific departure and arrival stations. Two new histogram datasets are introduced to support this functionality, along with updated filtering logic throughout the application.

## Key Changes

**Data Layer (`scripts/build_gold.py`)**
- Added two new aggregated datasets:
  - `hist_stazioni_mese_categoria_ruolo`: Monthly station-level histogram with departure/arrival role perspective
  - `hist_stazioni_giorno_categoria_ruolo`: Daily station-level histogram with departure/arrival role perspective
- Both datasets group by station code, role (partenza/arrivo), and delay buckets to enable station-specific analysis

**Frontend (`docs/assets/app.js`)**
- Added new state properties to store the station-level histogram data
- Introduced `hasStationFilter()` helper function to detect when departure or arrival filters are active
- Updated `renderKPI()` to use origin-destination (OD) data when station filters are applied
- Updated `seriesDaily()` and `seriesMonthly()` to switch data sources based on station filtering
- Updated `renderHist()` to use station-level histogram data when station filters are active, with proper filtering by station code and role
- Added filtering logic in histogram rendering to match arrival stations with "arrivo" role and departure stations with "partenza" role

## Implementation Details
- Station filtering is implemented as an alternative data path rather than filtering the existing datasets, allowing for optimized pre-aggregated data
- The filtering logic properly handles the dual perspective (departure vs. arrival) by checking the role field in the station histogram data
- When station filters are active, the application uses OD-category data for KPI metrics and station-role data for histograms instead of the default category-only aggregations

https://claude.ai/code/session_01QECDKYuQsuFRTNa1cpngD5