### PR TITLE
Fix monthly silver truncation in daily pipeline

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -30,6 +30,17 @@ def month_keys_between(d0: date, d1: date) -> list[str]:
     return sorted(out)
 
 
+def expand_to_month_start(d0: date, d1: date) -> tuple[date, date]:
+    """
+    Espande l'intervallo per rigenerare il silver dall'inizio del mese coinvolto.
+
+    Questo evita di produrre parquet mensili parziali quando l'ambiente di esecuzione
+    non conserva i file silver tra un run e l'altro (es. GitHub Actions).
+    """
+    start_month = date(d0.year, d0.month, 1)
+    return start_month, d1
+
+
 def silver_path_for_month_key(month_key: str) -> str:
     y = month_key[:4]
     return os.path.join("data", "silver", y, f"{month_key}.parquet")
@@ -53,8 +64,19 @@ def run(start: date, end: date) -> None:
     # 1. Scarica dati raw
     call([sys.executable, "-m", "scripts.ingest", "--start", s, "--end", e])
     
-    # 2. Trasforma in silver
-    call([sys.executable, "-m", "scripts.transform_silver", "--start", s, "--end", e])
+    # 2. Trasforma in silver (month-to-date per evitare overwrite mensili parziali)
+    silver_start, silver_end = expand_to_month_start(start, end)
+    call(
+        [
+            sys.executable,
+            "-m",
+            "scripts.transform_silver",
+            "--start",
+            silver_start.isoformat(),
+            "--end",
+            silver_end.isoformat(),
+        ]
+    )
 
     # 3. Costruisci aggregazioni gold
     months = month_keys_between(start, end)


### PR DESCRIPTION
### Motivation
- The daily pipeline could overwrite a month-level silver parquet with only the requested day range when `data/silver` is not present on a fresh runner, producing undercounted gold metrics. 
- The intent is to ensure `transform_silver` always produces a complete monthly input so gold aggregations are computed from full-month silver files.

### Description
- Added `expand_to_month_start(d0, d1)` to `scripts/run_pipeline.py` to compute a start date anchored to the first day of the start month. 
- Changed the silver transform step to call `scripts.transform_silver` with the expanded range `--start <month-first>` through the requested end date. 
- Left gold rebuild scope unchanged (still uses `month_keys_between(start,end)`), so only the affected months are re-aggregated.

### Testing
- `python -m py_compile scripts/run_pipeline.py` completed successfully. 
- Sanity check of `expand_to_month_start` was run via a short script and returned the expected month-aligned tuples. 
- Executed `python -m scripts.transform_silver --start 2026-02-01 --end 2026-02-15` which reported `{'silver_updated_months': ['202602']}` indicating the month parquet was updated. 
- Attempted a full `python -m scripts.run_pipeline --start 2026-02-15 --end 2026-02-15` but the run could not complete due to an external network/proxy error contacting the source endpoint; this failure is environmental and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937eed9b84832a967237e8915b1bf0)